### PR TITLE
Version 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Change Log
 
 ### Table of Contents
+- [Version 3.5.1](#version-351---_2025-04-26_)
 - [Version 3.5.0](#version-350---_2025-04-26_)
 - [Version 3.4.1](#version-341---_2025-03-28_)
 - [Version 3.4.0](#version-340---_2025-02-25_)
@@ -34,6 +35,15 @@
 - [Version 3.0.1](#version-301---_2024-08-27_)
 - [Version 3.0.0](#version-300---_2024-08-18_)
 
+
+### [Version 3.5.1](https://github.com/tahoni/hpsc-web-vite/releases/tag/version-3.5.1) - _2025-04-26_
+Actually return HTTP status 404 for pages not found.<br/>
+
+#### General Code Improvements
+- Changed the `.htaccess` file to only allow known routes, other routes will automatically return a 404 HTTP status.
+
+#### Changes by
+@tahoni
 
 ### [Version 3.5.0](https://github.com/tahoni/hpsc-web-vite/releases/tag/version-3.5.0) - _2025-04-26_
 Used a better library for Google Maps.<br/>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,27 +1,11 @@
 # HPSC website
 ## Release Notes
 
-### [Version 3.5.0](https://github.com/tahoni/hpsc-web-vite/releases/tag/version-3.5.0) - _2025-04-26_
-Used a better library for Google Maps.<br/>
-Return HTTP status 404 for pages not found.<br/>
-
-#### Enhancements and Updates
-- Removed the Not Found component.
-- Removed the Page Not Found page.
+### [Version 3.5.1](https://github.com/tahoni/hpsc-web-vite/releases/tag/version-3.5.1) - _2025-04-26_
+Actually return HTTP status 404 for pages not found.<br/>
 
 #### General Code Improvements
-- Changed the `.htaccess` file to only allow known routes and return 404 for all other routes.
-
-#### General Technical Changes
-- Removed the IntelliJ config files.
-- Added the Visual Studio Code files.
-- Created environment variables for sensitive configs for all environments.
-
-#### Dependencies
-- Removed the Google Maps dependencies from `@react-google-maps`.
-- Added the Google Maps library from `@vis.gl/react-google-map`.
-- Mitigated vulnerable dependencies.
+- Changed the `.htaccess` file to only allow known routes, other routes will automatically return a 404 HTTP status.
 
 #### Changes by
 @tahoni
-@dependabot

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Leoni Lubbinge <tahoni@gmail.com>",
   "description": "HPSC website",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,15 +1,12 @@
 <IfModule mod_rewrite.c>
   RewriteEngine On
-  RewriteBase /
-
-  # Allow specific routes
-  RewriteRule ^home$ /index.html [L]
-  RewriteRule ^members$ /index.html [L]
-  RewriteRule ^links$ /index.html [L]
-  RewriteRule ^history$ /index.html [L]
-  RewriteRule ^about$ /index.html [L]
-  RewriteRule ^about_us$ /index.html [L]
-
-  # Return 404 for all other routes
-  RewriteRule .* - [R=404,L]
+  RewriteBase / 
+  RewriteRule ^index\.html$ - [L]
+  RewriteCond %{REQUEST_URI} "^$" [OR]
+  RewriteCond %{REQUEST_URI} "(home)" [OR]
+  RewriteCond %{REQUEST_URI} "(members)" [OR]
+  RewriteCond %{REQUEST_URI} "(links)" [OR]
+  RewriteCond %{REQUEST_URI} "(history)" [OR]
+  RewriteCond %{REQUEST_URI} "((about)|(about_us))"
+  RewriteRule . /index.html [L]
 </IfModule>

--- a/src/helpers/RouteHelpers.tsx
+++ b/src/helpers/RouteHelpers.tsx
@@ -5,6 +5,7 @@ import { AboutUs, History, Home, Links, Members } from "./Aliases.tsx";
 export const routes: PageAlias[] = [
   { mapping: Home },
   { path: "/home", mapping: Home, element: <Navigate to={"/"} /> },
+  { path: "/index.html", mapping: Home, element: <Navigate to={"/"} /> },
 
   { mapping: Members },
   { mapping: Links },


### PR DESCRIPTION
Actually return HTTP status 404 for pages not found.

#### General Code Improvements
- Changed the `.htaccess` file to only allow known routes, other routes will automatically return a 404 HTTP status.

#### Changes by
@tahoni
